### PR TITLE
 Fixed the title of the entries to use the correct name

### DIFF
--- a/radar/languages-and-frameworks/nextjs.md
+++ b/radar/languages-and-frameworks/nextjs.md
@@ -1,5 +1,5 @@
 ---
-title: "NextJS"
+title: "Next.js"
 ring: adopt
 quadrant: "languages-and-frameworks"
 tags: [frontend, web]

--- a/radar/methods-and-patterns/diagrams-as-code.md
+++ b/radar/methods-and-patterns/diagrams-as-code.md
@@ -1,5 +1,5 @@
 ---
-title: "Diagrams as code"
+title: "Diagrams as Code"
 ring: adopt
 quadrant: "methods-and-patterns"
 tags: [all]

--- a/radar/platforms-and-services/aws.md
+++ b/radar/platforms-and-services/aws.md
@@ -1,5 +1,5 @@
 ---
-title: "AWS Cloud Service Provider"
+title: "Amazon Web Services"
 ring: adopt
 quadrant: "platforms-and-aoe-services"
 tags: [cloud, platform, aws]

--- a/radar/platforms-and-services/azure.md
+++ b/radar/platforms-and-services/azure.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure Cloud Service Provider"
+title: "Microsoft Azure"
 ring: adopt
 quadrant: "platforms-and-aoe-services"
 tags: [cloud, platform, azure]

--- a/radar/tools/eslint.md
+++ b/radar/tools/eslint.md
@@ -1,7 +1,7 @@
 ---
 title: "ESLint"
 ring: adopt
-quadrant: "languages-and-frameworks"
+quadrant: "tools"
 tags: [typescript, javascript]
 ---
 


### PR DESCRIPTION
To avoid ambiguity and facilitate the consultation and maintenance of the technology radar we should ensure that each entry has the right `title`.

The title should:
- refer to a single technology
- use the "commercial" name of the technology or the name by which it is known in the community

(with ts PR I also fixed the `quadrant` of `ESlint`)