### PR TITLE
Diagram as Code as `trial` 

### DIFF
--- a/radar/methods-and-patterns/diagrams-as-code.md
+++ b/radar/methods-and-patterns/diagrams-as-code.md
@@ -1,6 +1,6 @@
 ---
 title: "Diagrams as Code"
-ring: adopt
+ring: trial
 quadrant: "methods-and-patterns"
 tags: [all]
 ---


### PR DESCRIPTION
I argue **Diagram as Code** is an established practice in PagoPA, although it's a very interesting one and something I would know more about.

I mark it as `trial` as it seems to me teams are still experimenting with it. Otherwise we can add to the page a reference to the repositories that are currently using Diagram as Code.