### PR TITLE
OpenAPI: differentiate v3 from v2

### DIFF
--- a/radar/methods-and-patterns/openapi2.md
+++ b/radar/methods-and-patterns/openapi2.md
@@ -1,0 +1,10 @@
+---
+title: "OpenAPI v2"
+ring: hold
+quadrant: "methods-and-patterns"
+tags: [all, api, integration]
+---
+
+The [OpenAPI Specification (OAS) v2](https://swagger.io/specification/v2), also known as Swagger used to be the standard version to document and automate API specifications.
+
+As [OpenAPI Specification (OAS) v3](openapi3.html) became publicly adopted, we no longer encourage the usage of OpenAPI v2.

--- a/radar/methods-and-patterns/openapi3.md
+++ b/radar/methods-and-patterns/openapi3.md
@@ -1,5 +1,5 @@
 ---
-title: "OpenAPI"
+title: "OpenAPI v3"
 ring: adopt
 quadrant: "methods-and-patterns"
 tags: [all, api, integration]


### PR DESCRIPTION
<!--
Hello 👋
Thank you for contributing to our Technology Radar by proposing changes.
When making a pull request to add content, please ensure that the following
things are done. When not relevant (ie. when making changes to scripts
or workflows), please remove this section and describe the purpose instead.
-->

I propose to be explicit on deprecate V2

- [x] I've added a short description of the entry that
      clarifies what it does and why it's useful
- [x] I've added links to the entry's documentation and/or
      website
- [x] My frontmatter is correct, complete and follows the
      format specified in the [README](../README.md)
- [ ] In case the entry is in the `adopt` category: I've
      added at least one reference to showcase the entry usage
      among our organization
- [ ] I've described at least one use case for the entry
