### PR TITLE
Add documentation for DevContainers to standardize development environments

### DIFF
--- a/radar/tools/devcontainer.md
+++ b/radar/tools/devcontainer.md
@@ -2,7 +2,7 @@
 title: "DevContainers"
 ring: trial
 quadrant: "tools"
-tags: [development, containerization]
+tags: [development, containerization, dx]
 ---
 
 [DevContainers](https://containers.dev/) are a way to configure a consistent

--- a/radar/tools/devcontainer.md
+++ b/radar/tools/devcontainer.md
@@ -1,0 +1,27 @@
+---
+title: "DevContainers"
+ring: trial
+quadrant: "tools"
+tags: [development, containerization]
+---
+
+[DevContainers](https://containers.dev/) are a way to configure a consistent
+development environment using Docker containers. They allow developers to work
+in a standardized environment, regardless of the underlying OS.
+
+- DevContainers are defined using a `devcontainer.json` file, which specifies
+  the Docker image, extensions, and settings to use.
+- They can be [used with Visual Studio
+  Code](https://code.visualstudio.com/docs/remote/containers), allowing
+  developers to open a project in a container with a single click.
+
+## Use cases
+
+- Simplifying the setup process for new developers
+- Standardizing development environments across different machines
+- Ensuring consistency between development and production environments
+- Remote development within GitHub Codespaces
+
+## Reference of usage in our organization
+
+https://github.com/search?q=org%3Apagopa+path%3Adevcontainer.json&type=code


### PR DESCRIPTION

- [X] I've added a short description of the entry that
      clarifies what it does and why it's useful
- [X] I've added links to the entry's documentation and/or
      website
- [X] My frontmatter is correct, complete and follows the
      format specified in the [README](../README.md)
