### PR TITLE
Add recommended setup instructions for Apple Silicon Macs in Rancher Desktop documentation

### DIFF
--- a/radar/tools/rancher-desktop.md
+++ b/radar/tools/rancher-desktop.md
@@ -9,6 +9,11 @@ tags: [containerization, kubernetes]
 application that provides Kubernetes and container management on your local
 machine.
 
+## Recommended setup for Apple Silicon Macs
+
+- `virtiofs` as Mount type for better FS performance
+- `VZ` as Virtual Machine Type with `Rosetta` enabled to run x86_64 images
+
 ## Use cases
 
 - Local development and testing of Kubernetes clusters


### PR DESCRIPTION
Include guidance on using `virtiofs` and `VZ` with `Rosetta` for improved performance on Apple Silicon Macs.