### PR TITLE
Add documentation for PM2 as a process manager for Node.js applications

### DIFF
--- a/radar/tools/pm2.md
+++ b/radar/tools/pm2.md
@@ -15,3 +15,7 @@ tags: [nodejs, compute]
 Use in Azure App Service to manage Node.js applications in production:
 
 https://learn.microsoft.com/en-us/azure/app-service/configure-language-nodejs?pivots=platform-linux#configure-nodejs-server
+
+## Reference of usage in our organization
+
+- [IO Session Manager](https://github.com/pagopa/io-infra/blob/main/src/domains/citizen-auth-app/08_session_manager.tf#L250)

--- a/radar/tools/pm2.md
+++ b/radar/tools/pm2.md
@@ -1,0 +1,17 @@
+---
+title: "PM2"
+ring: trial
+quadrant: "tools"
+tags: [nodejs, compute]
+---
+
+[PM2](https://pm2.keymetrics.io/) is a production process manager for Node.js applications with a built-in load balancer. It helps keep applications alive forever, reload them without downtime, and facilitate common system admin tasks.
+
+## Use cases
+
+- Managing Node.js applications in production
+- Ensuring high availability and uptime
+
+Use in Azure App Service to manage Node.js applications in production:
+
+https://learn.microsoft.com/en-us/azure/app-service/configure-language-nodejs?pivots=platform-linux#configure-nodejs-server

--- a/radar/tools/rancher-desktop.md
+++ b/radar/tools/rancher-desktop.md
@@ -1,0 +1,16 @@
+---
+title: "Rancher Desktop"
+ring: adopt
+quadrant: "tools"
+tags: [containerization, kubernetes]
+---
+
+[Rancher Desktop](https://rancherdesktop.io/) is an open-source desktop
+application that provides Kubernetes and container management on your local
+machine.
+
+## Use cases
+
+- Local development and testing of Kubernetes clusters
+- Managing containerized applications on a desktop environment
+- Simplifying the setup of Kubernetes for developers

--- a/radar/tools/rancher-desktop.md
+++ b/radar/tools/rancher-desktop.md
@@ -9,6 +9,11 @@ tags: [containerization, kubernetes]
 application that provides Kubernetes and container management on your local
 machine.
 
+## Recommended setup for Apple Silicon Macs
+
+- `virtiofs` as Mount type for better FS performance
+- `VZ` as Virtual Machine Type with `Rosetta` enabled to run x86_64 images
+
 ## Use cases
 
 - Local development and testing of Kubernetes clusters


### PR DESCRIPTION
Introduce documentation for PM2, detailing its use cases and benefits for managing Node.js applications in production environments.

- [X] I've added a short description of the entry that
      clarifies what it does and why it's useful
- [X] I've added links to the entry's documentation and/or
      website
- [X] My frontmatter is correct, complete and follows the
      format specified in the [README](../README.md)
- [x] In case the entry is in the `adopt` category: I've
      added at least one reference to showcase the entry usage
      among our organization
- [ ] I've described at least one use case for the entry
