### PR TITLE
Add CommonJS to tech radar

### DIFF
--- a/radar/languages-and-frameworks/commonjs.md
+++ b/radar/languages-and-frameworks/commonjs.md
@@ -1,0 +1,39 @@
+---
+title: "CommonJS"
+ring: hold
+quadrant: "languages-and-frameworks"
+tags: [javascript, nodejs, typescript]
+---
+
+[CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-modules) is a module system and module format that was originally designed for Node.js, allowing you to split JavaScript code into separate files and requiring them using the `require()` function. While it has been widely used in Node.js applications and was essential for the early development of the Node.js ecosystem, we recommend using ECMAScript Modules (ESM) instead for new projects.
+
+## Reasons for Hold Status
+
+1. **ESM is the Standard**: ECMAScript Modules is the official standardized module system for JavaScript, supported by modern browsers and Node.js. It provides a more consistent development experience across different environments.
+
+2. **Better Static Analysis**: ESM's static module structure enables better tree-shaking (dead code elimination) and optimization by bundlers, while CommonJS's dynamic nature makes these optimizations more difficult.
+
+3. **Asynchronous by Design**: ESM supports both synchronous and asynchronous module loading, while CommonJS is synchronous by nature, which can lead to performance bottlenecks.
+
+4. **Interoperability Issues**: Using CommonJS alongside ESM can lead to interoperability challenges, especially in projects that use both module systems. Some tools and libraries may require additional configuration or transpilation steps.
+
+## Migration Path
+
+When working with existing CommonJS projects:
+
+1. Use the `.cjs` extension for CommonJS files and `.mjs` for ESM files to make the module system explicit
+2. Add `"type": "module"` to your `package.json` to use ESM by default
+3. For new modules within existing projects, prefer using ESM syntax:
+   ```javascript
+   // Instead of CommonJS
+   const { foo } = require('bar');
+   module.exports = { baz };
+
+   // Use ESM
+   import { foo } from 'bar';
+   export { baz };
+   ```
+
+## Reference of usage in our organization
+
+While we still maintain some legacy projects using CommonJS, all new TypeScript/JavaScript projects should use ESM. For existing projects using CommonJS, consider gradually migrating to ESM when making substantial changes to the codebase.

--- a/radar/languages-and-frameworks/commonjs.md
+++ b/radar/languages-and-frameworks/commonjs.md
@@ -17,7 +17,7 @@ tags: [javascript, nodejs, typescript]
 
 4. **Interoperability Issues**: Using CommonJS alongside ESM can lead to interoperability challenges, especially in projects that use both module systems. Some tools and libraries may require additional configuration or transpilation steps.
 
-## Migration Path
+## Working with ESM
 
 When working with existing CommonJS projects:
 

--- a/radar/languages-and-frameworks/esm.md
+++ b/radar/languages-and-frameworks/esm.md
@@ -18,31 +18,29 @@ tags: [javascript, nodejs, typescript]
 
 3. **Asynchronous by Design**: ESM supports both synchronous and asynchronous module loading, making it more flexible than CommonJS.
 
-## Use Cases
-
-- New JavaScript/TypeScript projects where module organization is important
-- Projects that need to work in both browser and Node.js environments
-- Libraries that need to be tree-shakeable
-- Applications where bundle size optimization is critical
-
 ## Best Practices
 
-1. Use the `.mjs` extension for pure ESM files or set `"type": "module"` in your `package.json`
+1. Set `"type": "module"` in your `package.json` or use the `.mjs` extension (`.mts` on TypeScript) for pure ESM files
 2. Prefer named exports over default exports for better tooling support
-3. Keep modules focused and single-responsibility
-4. Use path aliases and module resolution to maintain clean import paths
 
 Example of ESM syntax:
+
 ```javascript
 // Importing
-import { function1, function2 } from './module';
-import * as module from './module';
+import { function1, function2 } from './module.js';
+import * as module from './module.js';
 
 // Exporting
 export const myFunction = () => {};
 export class MyClass {}
 ```
 
+### Why are extension mandatory?
+
+ESM requires explicit file extensions in import statements to ensure clarity and avoid ambiguity. This is a design choice that helps the JavaScript engine resolve modules correctly, especially in environments where both ESM and CommonJS coexist.
+
+When working with TypeScript, you still need to specify the `.js` file extension in your import statements, even if the original file is a TypeScript file.
+ 
 ## Typescript Support
 
 To use ESM in TypeScript, you need to configure your `tsconfig.json` file appropriately. Here’s an example configuration:
@@ -55,14 +53,3 @@ To use ESM in TypeScript, you need to configure your `tsconfig.json` file approp
   }
 }
 ```
-
-## Reference of usage in our organization
-
-ESM is used in our modern TypeScript/JavaScript projects as the default module system. Examples include:
-
-- Frontend applications built with Next.js
-- React Native applications
-- Node.js backend services
-- Shared utility libraries
-
-See also: [CommonJS](commonjs.md) (hold) for information about the legacy module system.

--- a/radar/languages-and-frameworks/esm.md
+++ b/radar/languages-and-frameworks/esm.md
@@ -1,0 +1,60 @@
+---
+title: "ECMAScript Modules"
+ring: adopt
+quadrant: "languages-and-frameworks"
+tags: [javascript, nodejs, typescript]
+---
+
+[ECMAScript Modules (ESM)](https://nodejs.org/api/esm.html) is the official standard format to package JavaScript code for reuse. It was standardized in 2015 as part of ECMAScript 2015 (ES6) and provides a robust, unified way to write modular JavaScript code that works both in browsers and Node.js.
+
+## Key Features
+
+1. **Static Module Structure**: ESM's static `import` and `export` statements enable better static analysis, allowing tools to:
+   - Perform tree-shaking (dead code elimination)
+   - Optimize module loading
+   - Create more efficient bundles
+
+2. **Native Support**: Modern browsers and Node.js support ESM natively, eliminating the need for transpilation in many cases.
+
+3. **Asynchronous by Design**: ESM supports both synchronous and asynchronous module loading, making it more flexible than CommonJS.
+
+4. **Better Developer Experience**:
+   - Clear dependency declarations at the top of files
+   - Named imports and exports for better code organization
+   - Better IDE support for code navigation and refactoring
+
+## Use Cases
+
+- New JavaScript/TypeScript projects where module organization is important
+- Projects that need to work in both browser and Node.js environments
+- Libraries that need to be tree-shakeable
+- Applications where bundle size optimization is critical
+
+## Best Practices
+
+1. Use the `.mjs` extension for pure ESM files or set `"type": "module"` in your `package.json`
+2. Prefer named exports over default exports for better tooling support
+3. Keep modules focused and single-responsibility
+4. Use path aliases and module resolution to maintain clean import paths
+
+Example of ESM syntax:
+```javascript
+// Importing
+import { function1, function2 } from './module';
+import * as module from './module';
+
+// Exporting
+export const myFunction = () => {};
+export class MyClass {}
+```
+
+## Reference of usage in our organization
+
+ESM is used in our modern TypeScript/JavaScript projects as the default module system. Examples include:
+
+- Frontend applications built with Next.js
+- React Native applications
+- Node.js backend services
+- Shared utility libraries
+
+See also: [CommonJS](commonjs.md) (hold) for information about the legacy module system.

--- a/radar/languages-and-frameworks/esm.md
+++ b/radar/languages-and-frameworks/esm.md
@@ -18,11 +18,6 @@ tags: [javascript, nodejs, typescript]
 
 3. **Asynchronous by Design**: ESM supports both synchronous and asynchronous module loading, making it more flexible than CommonJS.
 
-4. **Better Developer Experience**:
-   - Clear dependency declarations at the top of files
-   - Named imports and exports for better code organization
-   - Better IDE support for code navigation and refactoring
-
 ## Use Cases
 
 - New JavaScript/TypeScript projects where module organization is important

--- a/radar/languages-and-frameworks/esm.md
+++ b/radar/languages-and-frameworks/esm.md
@@ -43,6 +43,19 @@ export const myFunction = () => {};
 export class MyClass {}
 ```
 
+## Typescript Support
+
+To use ESM in TypeScript, you need to configure your `tsconfig.json` file appropriately. Here’s an example configuration:
+
+```json
+{
+  "compilerOptions": {
+    "module": "NodeNext", // Output ESM format
+    "moduleResolution": "NodeNext", // Use Node's module resolution algorithm
+  }
+}
+```
+
 ## Reference of usage in our organization
 
 ESM is used in our modern TypeScript/JavaScript projects as the default module system. Examples include:


### PR DESCRIPTION
This PR adds CommonJS to the tech radar in the 'hold' ring of the Languages and Frameworks quadrant.

**Why hold status?**
CommonJS, while historically important for Node.js, is being superseded by ECMAScript Modules (ESM) which offers:
- Better static analysis and tree-shaking capabilities
- Native browser and Node.js support
- Asynchronous module loading
- Future-proof standardization

The entry includes:
- Explanation of CommonJS and its historical importance
- Reasons to prefer ESM for new projects
- Migration guidance for existing CommonJS codebases